### PR TITLE
 修复 043adc0 引入的 SaaS 专有代码导致的编译错误

### DIFF
--- a/internal/bots/types.go
+++ b/internal/bots/types.go
@@ -114,19 +114,12 @@ type UpdatePromptsRequest struct {
 type ContainerLifecycle interface {
 	SetupBotContainer(ctx context.Context, botID string) error
 	CleanupBotContainer(ctx context.Context, botID string) error
-	InstallDefaultSkills(ctx context.Context, botID string) error
-	RegisterEvoMapNode(ctx context.Context, botID string) error
 }
 
 // HeartbeatSeeder seeds system heartbeat configs for a bot.
 type HeartbeatSeeder interface {
 	SeedEvolutionConfig(ctx context.Context, botID string) error
 	DisableEvolutionConfig(ctx context.Context, botID string) error
-}
-
-// ToolInitializer seeds default tool configurations for a newly created bot.
-type ToolInitializer interface {
-	InitializeDefaults(ctx context.Context, botID string) error
 }
 
 // RuntimeChecker produces runtime check items for a bot.


### PR DESCRIPTION
  问题描述

  在 commit 043adc0 "Sync bot templates from Memoh-v2-saas" 中，不小心将 SaaS
  版本的专有代码同步到了开源版本，导致以下编译错误：

  1. 导入路径错误：引用了不存在的 github.com/Kxiandaoyan/Memoh-v2-saas 仓库
  2. 缺失数据库查询方法：调用了 SaaS 版本独有的 ListAllBots() 方法
  3. 接口不匹配：在 ContainerLifecycle 接口中添加了 SaaS 专有方法 InstallDefaultSkills 和 RegisterEvoMapNode

  这些问题导致 Docker 构建失败，无法正常部署。

  修复内容

  本 PR 包含 3 个提交，分别修复上述问题：

  1. 修复导入路径 (18b141c)

  - 文件：internal/bots/service.go
  - 改动：将错误的 SaaS 仓库导入路径改为开源版本路径
  // 修复前
  "github.com/Kxiandaoyan/Memoh-v2-saas/internal/db"
  "github.com/Kxiandaoyan/Memoh-v2-saas/internal/db/sqlc"

  // 修复后
  "github.com/Kxiandaoyan/Memoh-v2/internal/db"
  "github.com/Kxiandaoyan/Memoh-v2/internal/db/sqlc"

  2. 移除 SaaS 专有查询方法 (380aa42)

  - 文件：internal/bots/service.go
  - 改动：删除调用 ListAllBots() 的 ListAll() 方法（该查询仅存在于 SaaS 版本数据库）

  3. 清理 SaaS 专有接口方法 (1c6cf27)

  - 文件：internal/bots/types.go, internal/bots/service.go
  - 改动：
    - 从 ContainerLifecycle 接口移除 InstallDefaultSkills 和 RegisterEvoMapNode 方法
    - 删除整个 ToolInitializer 接口
    - 移除 service.go 中相关的字段和方法调用

  测试验证

  - ✅ Docker 构建成功
  - ✅ 服务正常启动
  - ✅ 所有核心功能正常工作

  相关 Issue

  此问题由 commit 043adc0 引入，建议在合并 SaaS 代码时增加检查流程，避免将专有代码同步到开源版本。